### PR TITLE
0.0.4: Fix typo for _state_bump fund fn parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.0.4
+
+- Fix typo in `multisig_lite::fund` instruction.
+
 # Version 0.0.3
 
 - Fix the test link, changelog, as well as the license files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "multisig-lite"
-version = "0.0.2"
+version = "0.0.4"
 dependencies = [
  "anchor-lang",
 ]

--- a/programs/multisig-lite/CHANGELOG.md
+++ b/programs/multisig-lite/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.0.4
+
+- Fix typo in `multisig_lite::fund` instruction.
+
 # Version 0.0.3
 
 - Fix the test link, changelog, as well as the license files.

--- a/programs/multisig-lite/Cargo.toml
+++ b/programs/multisig-lite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "multisig-lite"
 # When publish a new version:
 # - Update CHANGELOG.md
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 authors = ["Keith Noguchi <keith@noguchi.us>"]
 license = "MIT OR Apache-2.0"

--- a/programs/multisig-lite/src/lib.rs
+++ b/programs/multisig-lite/src/lib.rs
@@ -425,7 +425,7 @@ pub mod multisig_lite {
     /// Funds lamports to the multisig account.
     ///
     /// The funding is only allowed by the multisig account funder.
-    pub fn fund(ctx: Context<Fund>, lamports: u64, _staet_bump: u8, fund_bump: u8) -> Result<()> {
+    pub fn fund(ctx: Context<Fund>, lamports: u64, _state_bump: u8, fund_bump: u8) -> Result<()> {
         let funder = &ctx.accounts.funder;
         let state = &mut ctx.accounts.state;
         let fund = &mut ctx.accounts.fund;


### PR DESCRIPTION
Since it's not reference by the function itself, it doesn't affect the runtime behavior.  But typo is typo. :)