### PR TITLE
Anchor.toml: Add local prefix in command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,11 @@ jobs:
       - name: Use the local cluster
         run: solana config set -u localhost
       - name: Run the local validator
-        run: anchor run validator
+        run: anchor run local-validator
       - name: Run anchor build
         run: anchor build -- --features localnet
       - name: Copy the program keypair file
-        run: anchor run cp-program-keypair
+        run: anchor run cp-local-program-keypair
       - name: Run anchor test
         run: anchor test --skip-local-validator --skip-build
 

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -17,6 +17,6 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 fmt = "cargo fmt && yarn lint:fix"
-validator = "solana-test-validator -r -q &"
-cp-program-keypair = "cp .github/keys/multisig_lite-keypair.json ./target/deploy/"
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+local-validator = "solana-test-validator -r -q &"
+cp-local-program-keypair = "cp .github/keys/multisig_lite-keypair.json ./target/deploy/"

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Run those anchor commands on the [Solana local development] environment:
 ```
 $ yarn
 $ anchor build -- --features localnet
-$ anchor run cp-program-keypair
-$ anchor run validator
+$ anchor run cp-local-program-keypair
+$ anchor run local-validator
 $ anchor test --skip-build --skip-local-validator
 ```
 


### PR DESCRIPTION
Just to avoid the confusion it may cause,
especially program keypair.  It's there
just for the CI purpose, nothing encouraging
to share the private key.  The private keys
should be private. :)