### PR TITLE
app: Keep the multisig PDAs under store

### DIFF
--- a/app/src/lib/Multisig.svelte
+++ b/app/src/lib/Multisig.svelte
@@ -1,0 +1,42 @@
+<script>
+	import { multisig } from '../stores/program';
+</script>
+
+<h1>Your Multisig Wallet Info</h1>
+
+{#if $multisig}
+	<ul>
+		<li>
+			State address:
+			{#await multisig.statePda()}
+				...
+			{:then pda}
+				{pda.toString()}
+			{/await}
+		</li>
+		<li>
+			State bump:
+			{#await multisig.stateBump()}
+				...
+			{:then bump}
+				{bump}
+			{/await}
+		</li>
+		<li>
+			Fund address:
+			{#await multisig.fundPda()}
+				...
+			{:then pda}
+				{pda.toString()}
+			{/await}
+		</li>
+		<li>
+			Fund bump:
+			{#await multisig.fundBump()}
+				...
+			{:then bump}
+				{bump}
+			{/await}
+		</li>
+	</ul>
+{/if}

--- a/app/src/routes/+layout.ts
+++ b/app/src/routes/+layout.ts
@@ -9,13 +9,12 @@
 
 import { get } from 'svelte/store';
 import { Connection, clusterApiUrl } from '@solana/web3.js';
-import { AnchorProvider, Program } from '@project-serum/anchor';
+import { AnchorProvider } from '@project-serum/anchor';
 import { browser } from '$app/environment';
 import { wallet, Wallet } from '../stores/wallet';
 import { cluster } from '../stores/cluster';
 import { provider } from '../stores/provider';
 import { multisig } from '../stores/program';
-import multisigIdl from '../idl/multisig_lite.json';
 
 // https://kit.svelte.dev/docs/load#layout-data
 export const load = () => {
@@ -68,10 +67,7 @@ function onConnect() {
 	provider.set(newProvider);
 
 	// and the multisig program.
-	if (!multisigIdl.metadata || !provider) return undefined;
-	const programId = multisigIdl.metadata.address;
-	const newMultisig = new Program(multisigIdl, programId, newProvider);
-	multisig.set(newMultisig);
+	multisig.set(newProvider);
 }
 
 function onDisconnect() {

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,9 +1,5 @@
 <script>
-	import { multisig } from '../stores/program';
+	import Multisig from '$lib/Multisig.svelte';
 </script>
 
-<h1>multisig-lite</h1>
-
-{#if $multisig}
-	<p>ProgramID: {$multisig.programId}</p>
-{/if}
+<Multisig />

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,17 +1,9 @@
 <script>
-	import { Program } from '@project-serum/anchor';
-	import { provider } from '../stores/provider';
-	import idl from '../idl/multisig_lite.json';
-
-	$: program = newProgram($provider);
-	function newProgram(provider) {
-		if (!idl.metadata || !provider) return undefined;
-		return new Program(idl, idl.metadata.address, provider);
-	}
+	import { multisig } from '../stores/program';
 </script>
 
 <h1>multisig-lite</h1>
 
-{#if program}
-	<p>ProgramID: {program.programId}</p>
+{#if $multisig}
+	<p>ProgramID: {$multisig.programId}</p>
 {/if}

--- a/app/src/stores/program.ts
+++ b/app/src/stores/program.ts
@@ -1,6 +1,84 @@
-import { Program } from '@project-serum/anchor';
-import { writable } from 'svelte/store';
-import type { Writable } from 'svelte/store';
-import idl from '../idl/multisig_lite.json';
+import { PublicKey } from '@solana/web3.js';
+import { utils, Program } from '@project-serum/anchor';
+import type { Provider } from '@project-serum/anchor';
+import { get, writable } from 'svelte/store';
+import multisigIdl from '../idl/multisig_lite.json';
 
-export const multisig: Writable<Program> = writable(undefined);
+class Multisig {
+	constructor() {
+		this._program = writable(undefined);
+		this._statePda = undefined;
+	}
+
+	subscribe(run) {
+		return this._program.subscribe(run);
+	}
+
+	set(provider: Provider) {
+		const idl = multisigIdl;
+		if (!provider || !idl.metadata || !idl.metadata.address) {
+			this._program.set(undefined);
+			this._statePda = undefined;
+			this._stateBump = undefined;
+			this._fundPda = undefined;
+			this._fundBump = undefined;
+			return;
+		}
+		const programId = idl.metadata.address;
+		this._program.set(new Program(idl, programId, provider));
+	}
+
+	async statePda(): Promise<PublicKey | undefined> {
+		let program = get(this._program);
+		if (!program) return undefined;
+		if (this._statePda) return this._statePda;
+		const [pda, bump] = await PublicKey.findProgramAddress(
+			[utils.bytes.utf8.encode('state'), program.provider.publicKey.toBuffer()],
+			program.programId
+		);
+		this._statePda = pda;
+		this._stateBump = bump;
+		return pda;
+	}
+
+	async stateBump(): Promise<number | undefined> {
+		let program = get(this._program);
+		if (!program) return undefined;
+		if (this._stateBump) return this._stateBump;
+		const [pda, bump] = await PublicKey.findProgramAddress(
+			[utils.bytes.utf8.encode('state'), program.provider.publicKey.toBuffer()],
+			program.programId
+		);
+		this._statePda = pda;
+		this._stateBump = bump;
+		return bump;
+	}
+
+	async fundPda(): Promise<PublicKey | undefined> {
+		let program = get(this._program);
+		if (!program) return undefined;
+		if (this._fundPda) return this._fundPda;
+		const [pda, bump] = await PublicKey.findProgramAddress(
+			[utils.bytes.utf8.encode('fund'), program.provider.publicKey.toBuffer()],
+			program.programId
+		);
+		this._fundPda = pda;
+		this._fundBump = bump;
+		return pda;
+	}
+
+	async fundBump(): Promise<number | undefined> {
+		let program = get(this._program);
+		if (!program) return undefined;
+		if (this._stateBump) return this._stateBump;
+		const [pda, bump] = await PublicKey.findProgramAddress(
+			[utils.bytes.utf8.encode('fund'), program.provider.publicKey.toBuffer()],
+			program.programId
+		);
+		this._fundPda = pda;
+		this._fundBump = bump;
+		return bump;
+	}
+}
+
+export const multisig = new Multisig();

--- a/app/src/stores/program.ts
+++ b/app/src/stores/program.ts
@@ -1,0 +1,6 @@
+import { Program } from '@project-serum/anchor';
+import { writable } from 'svelte/store';
+import type { Writable } from 'svelte/store';
+import idl from '../idl/multisig_lite.json';
+
+export const multisig: Writable<Program> = writable(undefined);

--- a/app/src/stores/program.ts
+++ b/app/src/stores/program.ts
@@ -29,55 +29,49 @@ class Multisig {
 	}
 
 	async statePda(): Promise<PublicKey | undefined> {
-		let program = get(this._program);
+		const program = get(this._program);
 		if (!program) return undefined;
 		if (this._statePda) return this._statePda;
-		const [pda, bump] = await PublicKey.findProgramAddress(
-			[utils.bytes.utf8.encode('state'), program.provider.publicKey.toBuffer()],
-			program.programId
-		);
+		const [pda, bump] = await this.findPda(program, 'state');
 		this._statePda = pda;
 		this._stateBump = bump;
 		return pda;
 	}
 
 	async stateBump(): Promise<number | undefined> {
-		let program = get(this._program);
+		const program = get(this._program);
 		if (!program) return undefined;
 		if (this._stateBump) return this._stateBump;
-		const [pda, bump] = await PublicKey.findProgramAddress(
-			[utils.bytes.utf8.encode('state'), program.provider.publicKey.toBuffer()],
-			program.programId
-		);
+		const [pda, bump] = await this.findPda(program, 'state');
 		this._statePda = pda;
 		this._stateBump = bump;
 		return bump;
 	}
 
 	async fundPda(): Promise<PublicKey | undefined> {
-		let program = get(this._program);
+		const program = get(this._program);
 		if (!program) return undefined;
-		if (this._fundPda) return this._fundPda;
-		const [pda, bump] = await PublicKey.findProgramAddress(
-			[utils.bytes.utf8.encode('fund'), program.provider.publicKey.toBuffer()],
-			program.programId
-		);
+		const [pda, bump] = await this.findPda(program, 'fund');
 		this._fundPda = pda;
 		this._fundBump = bump;
 		return pda;
 	}
 
 	async fundBump(): Promise<number | undefined> {
-		let program = get(this._program);
+		const program = get(this._program);
 		if (!program) return undefined;
 		if (this._stateBump) return this._stateBump;
-		const [pda, bump] = await PublicKey.findProgramAddress(
-			[utils.bytes.utf8.encode('fund'), program.provider.publicKey.toBuffer()],
-			program.programId
-		);
+		const [pda, bump] = await this.findPda(program, 'fund');
 		this._fundPda = pda;
 		this._fundBump = bump;
 		return bump;
+	}
+
+	async findPda(program: Program, name: string): Promise<[PublicKey, number]> {
+		return await PublicKey.findProgramAddress(
+			[utils.bytes.utf8.encode(name), program.provider.publicKey.toBuffer()],
+			program.programId
+		);
 	}
 }
 


### PR DESCRIPTION
It shows the multisig PDAs and bumps, which is managed under
the svelte store.

It follows the class store demo in svelte doc[1].

[1]: https://svelte.dev/repl/8e3f4f664cc14710afce0c9683e04652?version=3.42.6