### PR TITLE
app: /multisig for multisig page

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -1,15 +1,24 @@
 <script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
 	import FaGithub from 'svelte-icons/fa/FaGithub.svelte';
 	import FaGithubAlt from 'svelte-icons/fa/FaGithubAlt.svelte';
 	import FaWallet from 'svelte-icons/fa/FaWallet.svelte';
-	import { goto } from '$app/navigation';
 	import Button from '$lib/Button.svelte';
 	import Account from '$lib/Account.svelte';
 	import { wallet } from '../stores/wallet';
 	import { cluster } from '../stores/cluster';
+	import { multisig } from '../stores/program';
 	import type { LayoutData } from './$types';
 
 	export let data: LayoutData;
+
+	// Move back to the top page in case no multisig
+	// program is detected.
+	$: if (browser && !$multisig && $page.route.id != '/') {
+		goto('/');
+	}
 
 	let githubSrc = 'https://github.com/keithnoguchi/multisig-lite/tree/main/app';
 	let solIconSrc =

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,22 +1,21 @@
 <script>
 	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 	import { multisig } from '../stores/program';
 	import Button from '$lib/Button.svelte';
-	import Multisig from '$lib/Multisig.svelte';
 </script>
 
-{#if !$multisig}
-	<h1 class="main">Welcome!</h1>
-
-	<div class="main">
-		<Button on:click={() => $page.data.connect()} shadow>Connect with your wallet</Button>
-	</div>
-{:else}
-	<Multisig />
+{#if $multisig}
+	{goto('/multisig')}
 {/if}
 
+<h1 class="center">Welcome!</h1>
+<div class="center">
+	<Button on:click={() => $page.data.connect()} shadow>Connect with your wallet</Button>
+</div>
+
 <style>
-	.main {
+	.center {
 		display: flex;
 		justify-content: center;
 	}

--- a/app/src/routes/multisig/+page.svelte
+++ b/app/src/routes/multisig/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import Button from '$lib/Button.svelte';
-	import { multisig } from '../stores/program';
+	import { multisig } from '../../stores/program';
 </script>
 
 <h1>Your Multisig Wallet Info</h1>


### PR DESCRIPTION
Experimenting SvelteKit routing
with the goto function.

This helps to simplify the form
support under the multisig page,
and beyond.